### PR TITLE
Create deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ jobs:
         
       - name: install node
         uses: actions/setup-node@v3
+        # using later versions of node breaks due to react-scripts v5.0.1 incompatible with typescript v5;
+        # this specific node/npm version works though
         with:
           node-version: "16.14.2"
           npm: "8.5.0"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,8 @@ jobs:
       - name: install node
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "16.14.2"
+          npm: "8.5.0"
           
       - name: install dependencies
         run: npm install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: deploy
 on:
-  workflow-dispatch:
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-deploy:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
     steps:
       - name: checkout code

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: deploy-react-app-to-s3
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3
+        
+      - name: install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          
+      - name: install dependencies
+        run: npm install
+        
+      - name: run tests
+        run: npm run test
+        
+      - name: build project
+        run: npm run build
+        
+      - name: configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: deploy to S3 bucket
+        run: aws s3 sync ./build/ s3://portfolijo --delete

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     if: github.event.pull_request.merged == true
     steps:
       - name: checkout code

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, edited]
+    types: [opened, synchronize, reopened] # synchronize = new commits pushed
 
 jobs:
   test-and-build:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,15 +1,14 @@
-name: deploy
+name: test-build
 on:
   workflow-dispatch:
   pull_request:
     branches:
       - main
-    types: closed
+    types: [opened, edited]
 
 jobs:
-  build-and-deploy:
+  test-and-build:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
     steps:
       - name: checkout code
         uses: actions/checkout@v3
@@ -27,13 +26,3 @@ jobs:
         
       - name: build project
         run: npm run build
-        
-      - name: configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-
-      - name: deploy to S3 bucket
-        run: aws s3 sync ./build/ s3://portfolijo --delete

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-and-build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,6 +1,6 @@
 name: test-build
 on:
-  workflow-dispatch:
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -15,6 +15,8 @@ jobs:
         
       - name: install node
         uses: actions/setup-node@v3
+        # using later versions of node breaks due to react-scripts v5.0.1 incompatible with typescript v5;
+        # this specific node/npm version works though
         with:
           node-version: "16.14.2"
           npm: "8.5.0"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-and-build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -16,7 +16,8 @@ jobs:
       - name: install node
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "16.14.2"
+          npm: "8.5.0"
           
       - name: install dependencies
         run: npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "portfolio",
+  "name": "portfolijo",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "portfolio",
+      "name": "portfolijo",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/styled": "^11.10.6",


### PR DESCRIPTION
Cannot use later versions of node than specified in the workflow. react-scripts v5.0.1 is not compatible with typescript v5 but the specified node version does not throw an error during npm install (later versions do).